### PR TITLE
feat: 添加了Teamcraft风格的材料清单可选增强项

### DIFF
--- a/src/components/custom-controls/ItemList.vue
+++ b/src/components/custom-controls/ItemList.vue
@@ -110,9 +110,10 @@ const mode = ref<"default" | "list">('default')
 
 const listValue = computed(() => {
   const result : string[] = []
+  const tcStyle = userConfig.value.use_tc_style_item_list;
   props.items.forEach(item => {
     if (item.amount) {
-      result.push(`${getItemName(item)} x ${item.amount}`)
+      result.push(tcStyle ? `${item.amount}x ${getItemName(item)}` : `${getItemName(item)} x ${item.amount}`)
     }
   })
   return result.join('\n')

--- a/src/components/modals/ModalUserPreferences.vue
+++ b/src/components/modals/ModalUserPreferences.vue
@@ -351,6 +351,25 @@ const UserPreferenceGroups : UserPreferenceGroup[] = [
         options: []
       },
       {
+        key: 'use_tc_style_item_list',
+        label: t('使用Teamcraft风格材料清单'),
+        descriptions: [
+          {
+            value: t('Teamcraft风格的清单即为由"<itemCount>x <itemName>"格式的条目组成的清单。'),
+            class: '',
+            style: ''
+          },
+          {
+            value: t('如果你使用了其他兼容Teamcraft材料清单的程序，可以打开此选项以提供导入支持。'),
+            class: '',
+            style: ''
+          }
+        ],
+        warnings: [],
+        type: 'switch',
+        options: []
+      },
+      {
         key: 'macro_copy_prefix',
         label: t('默认宏前缀'),
         descriptions: [],

--- a/src/models/user-config.ts
+++ b/src/models/user-config.ts
@@ -17,6 +17,7 @@ export interface UserConfigModel {
   use_traditional_statement: boolean
   click_to_show_pop_in_span: boolean
   macro_direct_copy: boolean
+  use_tc_style_item_list: boolean
   macro_copy_prefix: string
   item_button_click_event: 'none' | 'copy_name' | 'copy_isearch'
   item_info_icon_click_event: 'none' | 'copy_name' | 'copy_isearch'
@@ -69,6 +70,7 @@ const defaultUserConfig: UserConfigModel = {
   use_traditional_statement: false,
   click_to_show_pop_in_span: false,
   macro_direct_copy: false,
+  use_tc_style_item_list: false,
   macro_copy_prefix: '',
   item_button_click_event: 'none',
   item_info_icon_click_event: 'none',


### PR DESCRIPTION
<!-- 简要描述该拉取请求的更改内容 -->
<!-- # Description -->
<!-- Briefly describe the changes made of this pull request. -->

原PR说明
> 此PR在原"清单"按钮旁边添加了"Teamcraft风格清单"按钮，令文本框显示Teamcraft风格的材料清单。Teamcraft风格的材料清单的条目形如<itemCount>x <itemName>。
> 
> Teamcraft风格的材料清单具有更好的其他工具兼容性，故添加此功能。

已经按照 #58 中建议的方案修改，将选项放在了偏好设置-增强中。