### PR TITLE
重构 选择部件 区域下拉菜单的渲染模式

### DIFF
--- a/src/assets/custom.css
+++ b/src/assets/custom.css
@@ -171,10 +171,6 @@
 .n-badge {
   font-family: inherit;
 }
-.n-dropdown-menu {
-  margin-top: 0 !important;
-  margin-bottom: 0 !important;
-}
 .n-option-hideoverflow {
   .n-dropdown-option-body__label {
     overflow: hidden;

--- a/src/components/custom/general/TooltipButton.vue
+++ b/src/components/custom/general/TooltipButton.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { inject, ref, computed, type Ref, type Component } from 'vue'
 import {
-  NButton, NIcon, NPopover,
+  NButton, NIcon, NPopover, NTooltip,
   type PopoverTrigger
 } from 'naive-ui'
 import type { Type } from 'naive-ui/es/button/src/interface'
@@ -11,11 +11,15 @@ const isMobile = inject<Ref<boolean>>('isMobile') ?? ref(false)
 interface TooltipButtonProps {
   size?: "tiny" | "small" | "medium" | "large",
   type?: Type,
+  tertiary?: boolean,
+  quaternary?: boolean,
   square?: boolean,
+  btnStyle?: string,
   icon?: Component,
   iconSize?: number,
   text?: string,
   tip?: string | string[],
+  tipType?: "n-popover" | "n-tooltip",
   placement?: import("vueuc/lib/binder/src/interface").Placement,
   popTrigger?: PopoverTrigger,
 }
@@ -36,6 +40,12 @@ const tips = computed(() => {
     return [props.tip]
   }
 })
+const tipComponent = computed(() => {
+  if (props.tipType === 'n-tooltip') {
+    return NTooltip
+  }
+  return NPopover
+})
 const popTrigger = computed(() => props.popTrigger ?? (isMobile.value ? 'manual' : 'hover'))
 
 const handleButtonClick = () => {
@@ -44,9 +54,16 @@ const handleButtonClick = () => {
 </script>
 
 <template>
-  <n-popover :trigger="popTrigger" :placement="placement">
+  <component :is="tipComponent" :trigger="popTrigger" :placement="placement">
     <template #trigger>
-      <n-button :size="size" :class="btnClass" @click="handleButtonClick">
+      <n-button
+        :tertiary="tertiary" 
+        :quaternary="quaternary" 
+        :size="size" 
+        :class="btnClass" 
+        :style="btnStyle" 
+        @click="handleButtonClick"
+      >
         <template #icon>
           <slot name="icon">
             <n-icon v-if="icon && !square" :size="iconSize" :component="icon" />
@@ -63,7 +80,7 @@ const handleButtonClick = () => {
         <div v-for="(tip, tipIndex) in tips" :key="'tip-' + tipIndex">{{ tip }}</div>
       </div>
     </slot>
-  </n-popover>
+  </component>
 </template>
 
 <style scoped>

--- a/src/components/custom/general/TooltipButton.vue
+++ b/src/components/custom/general/TooltipButton.vue
@@ -22,6 +22,7 @@ interface TooltipButtonProps {
   tipType?: "n-popover" | "n-tooltip",
   placement?: import("vueuc/lib/binder/src/interface").Placement,
   popTrigger?: PopoverTrigger,
+  popStyle?: string,
 }
 const props = defineProps<TooltipButtonProps>()
 const emits = defineEmits(['click'])
@@ -54,7 +55,7 @@ const handleButtonClick = () => {
 </script>
 
 <template>
-  <component :is="tipComponent" :trigger="popTrigger" :placement="placement">
+  <component :is="tipComponent" :trigger="popTrigger" :placement="placement" :style="popStyle">
     <template #trigger>
       <n-button
         :tertiary="tertiary" 

--- a/src/components/main/GearSelectionPanel.vue
+++ b/src/components/main/GearSelectionPanel.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { ref, computed, inject, watch,  } from 'vue'
+import { ref, computed, inject } from 'vue'
 import type { Ref } from 'vue'
 import {
-  NAlert, NButton, NButtonGroup, NDropdown, NDivider, NFlex, NIcon, NPopover,
-  useMessage, type DropdownOption
+  NAlert, NButton, NButtonGroup, NDivider, NFlex, NIcon, NPopover,
+  useMessage,
 } from 'naive-ui'
 import { 
   JoinLeftOutlined,
@@ -24,13 +24,11 @@ import { getDefaultGearSelections } from '@/models/gears'
 import { type UserConfigModel } from '@/models/config-user'
 import type { IHqVer } from '@/tools/nbb-cal-v5'
 import { useGearAdder } from '@/tools/gears'
-import useUiTools from '@/tools/ui'
 
 const t = inject<(text: string, ...args: any[]) => string>('t') ?? (() => { return '' })
 const isMobile = inject<Ref<boolean>>('isMobile') ?? ref(false)
 const userConfig = inject<Ref<UserConfigModel>>('userConfig')!
 const NAIVE_UI_MESSAGE = useMessage()
-const { optionsRenderer } = useUiTools(isMobile)
 
 const gearSelections = defineModel<GearSelections>('gearSelections', { required: true })
 export interface GearSelectionPanelProps {
@@ -216,47 +214,28 @@ const displayQuickOperates = computed(() => {
   // * 简单算法，有刻木主手代表是有生产采集新装的版本
   return !!props.patchData?.jobs?.MainHand?.[8]?.[0]
 })
-const showQuickOperatesOptions = ref(false)
-const handleQuickOperatesDropdownMouseEnter = (event: MouseEvent) => {
-  if (isMobile.value) return
-  if ((event.target as HTMLButtonElement).disabled) return
-  showQuickOperatesOptions.value = true
-}
-const handleQuickOperatesDropdownMouseLeave = (event: MouseEvent) => {
-  if (isMobile.value) return
-  if ((event.target as HTMLButtonElement).disabled) return
-  showQuickOperatesOptions.value = false
-}
-const handleCloseQuickOperatesOptions = () => {
-  showQuickOperatesOptions.value = false
-}
+
 const quickOperatesOptions = computed(() => {
   return [
     {
       key: 'add-crafter-mainoff',
       label: t('添加一套生产|全职业主副手'),
-      description: t('添加所有能工巧匠职业的主手工具、副手工具各1件')
+      description: t('添加所有能工巧匠职业的主手&副手工具各1件。')
     },
     {
       key: 'add-gatherer-mainoff',
       label: t('添加一套采集|全职业主副手'),
-      description: t('添加所有大地使者职业的主手工具、副手工具各1件')
+      description: t('添加所有大地使者职业的主手&副手工具各1件。')
     },
     {
       key: 'add-crafter-aaa', 
       label: t('添加一套生产|防具&首饰'), 
-      description: [
-        t('添加一套能工巧匠职业共用的防具与首饰。'),
-        t('如果没有首饰则不会添加。'),
-      ] 
+      description: t('添加一套能工巧匠职业共用的防具与首饰。'),
     },
     { 
       key: 'add-gatherer-aaa', 
       label: t('添加一套采集|防具&首饰'), 
-      description: [
-        t('添加一套大地使者职业共用的防具与首饰。'),
-        t('如果没有首饰则不会添加。'),
-      ] 
+      description: t('添加一套大地使者职业共用的防具与首饰。'),
     },
   ].map(item => {
     return {
@@ -287,25 +266,12 @@ const handleQuickOperatesSelect = (key: string) => {
   }
 }
 
-
-const showClearOptions = ref(false)
-const handleClearDropdownMouseEnter = (event: MouseEvent) => {
-  if (isMobile.value) return
-  if ((event.target as HTMLButtonElement).disabled) return
-  showClearOptions.value = true
-}
-const handleClearDropdownMouseLeave = (event: MouseEvent) => {
-  if (isMobile.value) return
-  if ((event.target as HTMLButtonElement).disabled) return
-  showClearOptions.value = false
-}
-const handleCloseClearOptions = () => {
-  showClearOptions.value = false
-}
-const clearOptions: DropdownOption[] = [
-  { key: 'clear-current', label: t('清空当前'), description: t('清空当前职业的已选择部件') },
-  { key: 'clear-all', label: t('清空全部'), description: t('清空所有职业的已选择部件') },
-]
+const clearOptions = computed(() => {
+  return [
+    { key: 'clear-current', label: t('清空当前'), description: t('清空当前职业的已选择部件。') },
+    { key: 'clear-all', label: t('清空全部'), description: t('清空所有职业的已选择部件。') },
+  ]
+})
 const handleClearSelect = (key: string) => {
   if (key === 'clear-current') {
     clearCurrent()
@@ -314,21 +280,7 @@ const handleClearSelect = (key: string) => {
   }
 }
 
-const showAddsuitOptions = ref(false)
-const handleAddsuitDropdownMouseEnter = (event: MouseEvent) => {
-  if (isMobile.value) return
-  if ((event.target as HTMLButtonElement).disabled) return
-  showAddsuitOptions.value = true
-}
-const handleAddsuitDropdownMouseLeave = (event: MouseEvent) => {
-  if (isMobile.value) return
-  if ((event.target as HTMLButtonElement).disabled) return
-  showAddsuitOptions.value = false
-}
-const handleCloseAddsuitOptions = () => {
-  showAddsuitOptions.value = false
-}
-const addsuitOptions = computed(() : DropdownOption[] => {
+const addsuitOptions = computed(() => {
   return [
     {
       key: 'add-weapon',
@@ -368,32 +320,8 @@ const handleAddsuitSelect = (key: string) => {
     addAttireAndAccessory()
   } else if (key === 'add-suit') {
     addAll()
-  } else if (key === 'add-selfdef') {
-    // // TODO: Add Self-defined Suit
   }
 }
-
-// keep only one dropdown open at a time
-watch(showQuickOperatesOptions, (newValue) => {
-  if (newValue) {
-    showClearOptions.value = false
-    showAddsuitOptions.value = false
-  }
-})
-watch(showClearOptions, (newValue) => {
-  if (newValue) {
-    showQuickOperatesOptions.value = false
-    showAddsuitOptions.value = false
-  }
-})
-watch(showAddsuitOptions, (newValue) => {
-  if (newValue) {
-    showQuickOperatesOptions.value = false
-    showClearOptions.value = false
-  }
-})
-
-// #endregion
 
 defineExpose({
   addCurrMainOffHand
@@ -574,14 +502,12 @@ defineExpose({
             class="no-select"
             placement="bottom"
             :trigger="isMobile ? 'click' : 'hover'"
+            style="--n-padding: 6px;"
           >
             <template #trigger>
               <n-button
                 icon-placement="right"
                 :disabled="jobNotSelected"
-                @click="showQuickOperatesOptions = !showQuickOperatesOptions"
-                @mouseenter="handleQuickOperatesDropdownMouseEnter"
-                @mouseleave="handleQuickOperatesDropdownMouseLeave"
               >
                 <template #icon>
                   <n-icon><KeyboardArrowDownRound /></n-icon>
@@ -593,10 +519,12 @@ defineExpose({
               <TooltipButton
                 v-for="(option, optionIndex) in quickOperatesOptions"
                 :key="option.key"
+                quaternary
                 :tip="option.description"
                 tip-type="n-tooltip"
                 :placement="optionIndex > 1 ? 'bottom' : 'top'"
-                btn-style="--n-padding: 7px 16px; --n-height: auto;"
+                btn-style="--n-padding: 8px 16px; --n-height: auto;"
+                pop-style="width: max-content;"
                 @click="handleQuickOperatesSelect(option.key)"
               >
                 <div>
@@ -610,54 +538,67 @@ defineExpose({
               </TooltipButton>
             </div>
           </n-popover>
-          <n-dropdown
-            :show="showClearOptions"
-            :options="clearOptions"
-            :render-option="optionsRenderer"
+          <n-popover
             class="no-select"
             placement="bottom"
-            @select="handleClearSelect"
-            @mouseenter="handleClearDropdownMouseEnter"
-            @mouseleave="handleClearDropdownMouseLeave"
-            :on-clickoutside="handleCloseClearOptions"
+            :trigger="isMobile ? 'click' : 'hover'"
+            style="--n-padding: 4px;"
           >
-            <n-button
-              icon-placement="right"
-              :disabled="jobNotSelected"
-              @click="showClearOptions = !showClearOptions"
-              @mouseenter="handleClearDropdownMouseEnter"
-              @mouseleave="handleClearDropdownMouseLeave"
-            >
-              <template #icon>
-                <n-icon><KeyboardArrowDownRound /></n-icon>
-              </template>
-              {{ t('清空') }}
-            </n-button>
-          </n-dropdown>
-          <n-dropdown
-            :show="showAddsuitOptions"
-            :options="addsuitOptions"
-            :render-option="optionsRenderer"
+            <template #trigger>
+              <n-button
+                icon-placement="right"
+                :disabled="jobNotSelected"
+              >
+                <template #icon>
+                  <n-icon><KeyboardArrowDownRound /></n-icon>
+                </template>
+                {{ t('清空') }}
+              </n-button>
+            </template>
+            <div class="flex-col gap-2">
+              <TooltipButton
+                v-for="option in clearOptions"
+                :key="option.key"
+                quaternary
+                :text="option.label"
+                :tip="option.description"
+                tip-type="n-tooltip"
+                placement="right"
+                pop-style="width: max-content;"
+                @click="handleClearSelect(option.key)"
+              />
+            </div>
+          </n-popover>
+          <n-popover
             class="no-select"
             placement="bottom"
-            @select="handleAddsuitSelect"
-            @mouseenter="handleAddsuitDropdownMouseEnter"
-            @mouseleave="handleAddsuitDropdownMouseLeave"
-            :on-clickoutside="handleCloseAddsuitOptions"
+            :trigger="isMobile ? 'click' : 'hover'"
+            style="--n-padding: 4px;"
           >
-            <n-button
-              icon-placement="right"
-              :disabled="jobNotSelected"
-              @click="showAddsuitOptions = !showAddsuitOptions"
-              @mouseenter="handleAddsuitDropdownMouseEnter"
-              @mouseleave="handleAddsuitDropdownMouseLeave"
-            >
-              <template #icon>
-                <n-icon><KeyboardArrowDownRound /></n-icon>
-              </template>
-              {{ t('添加') }}
-            </n-button>
-          </n-dropdown>
+            <template #trigger>
+              <n-button
+                icon-placement="right"
+                :disabled="jobNotSelected"
+              >
+                <template #icon>
+                  <n-icon><KeyboardArrowDownRound /></n-icon>
+                </template>
+                {{ t('添加') }}
+              </n-button>
+            </template>
+            <div class="flex-col gap-2">
+              <n-button
+                v-for="option in addsuitOptions"
+                :key="option.key"
+                quaternary
+                :disabled="option.disabled"
+                style="justify-content: start;"
+                @click="handleAddsuitSelect(option.key)"
+              >
+                {{ option.label }}
+              </n-button>
+            </div>
+          </n-popover>
         </n-flex>
       </div>
     </div>

--- a/src/components/main/GearSelectionPanel.vue
+++ b/src/components/main/GearSelectionPanel.vue
@@ -219,31 +219,25 @@ const quickOperatesOptions = computed(() => {
   return [
     {
       key: 'add-crafter-mainoff',
-      label: t('添加一套生产|全职业主副手'),
+      label: t('添加一套生产主副手'),
       description: t('添加所有能工巧匠职业的主手&副手工具各1件。')
     },
     {
       key: 'add-gatherer-mainoff',
-      label: t('添加一套采集|全职业主副手'),
+      label: t('添加一套采集主副手'),
       description: t('添加所有大地使者职业的主手&副手工具各1件。')
     },
     {
       key: 'add-crafter-aaa', 
-      label: t('添加一套生产|防具&首饰'), 
+      label: t('添加一套生产防具&首饰'), 
       description: t('添加一套能工巧匠职业共用的防具与首饰。'),
     },
     { 
       key: 'add-gatherer-aaa', 
-      label: t('添加一套采集|防具&首饰'), 
+      label: t('添加一套采集防具&首饰'), 
       description: t('添加一套大地使者职业共用的防具与首饰。'),
     },
-  ].map(item => {
-    return {
-      key: item.key,
-      labels: item.label.split('|'),
-      description: item.description,
-    }
-  })
+  ]
 })
 const handleQuickOperatesSelect = (key: string) => {
   if (jobNotSelected.value) {
@@ -499,10 +493,11 @@ defineExpose({
         <n-flex class="foot" justify="end">
           <n-popover
             v-if="displayQuickOperates"
-            class="no-select"
             placement="bottom"
             :trigger="isMobile ? 'click' : 'hover'"
-            style="--n-padding: 6px;"
+            :show-arrow="false"
+            class="no-select"
+            style="--n-padding: 4px;"
           >
             <template #trigger>
               <n-button
@@ -515,33 +510,26 @@ defineExpose({
                 {{ t('快速操作') }}
               </n-button>
             </template>
-            <div style="display: grid; gap: 4px 6px; grid-template-columns: minmax(0,1fr) minmax(0,1fr);">
+            <div class="flex-col gap-2">
               <TooltipButton
-                v-for="(option, optionIndex) in quickOperatesOptions"
+                v-for="option in quickOperatesOptions"
                 :key="option.key"
                 quaternary
+                :text="option.label"
                 :tip="option.description"
                 tip-type="n-tooltip"
-                :placement="optionIndex > 1 ? 'bottom' : 'top'"
-                btn-style="--n-padding: 8px 16px; --n-height: auto;"
+                placement="right"
+                btn-style="justify-content: start; --n-padding: 8px 16px; --n-height: auto;"
                 pop-style="width: max-content;"
                 @click="handleQuickOperatesSelect(option.key)"
-              >
-                <div>
-                  <p
-                    v-for="(label, labelIndex) in option.labels"
-                    :key="`quick-operate-label-${option.key}-${labelIndex}`"
-                  >
-                    {{ label }}
-                  </p>
-                </div>
-              </TooltipButton>
+              />
             </div>
           </n-popover>
           <n-popover
-            class="no-select"
             placement="bottom"
             :trigger="isMobile ? 'click' : 'hover'"
+            :show-arrow="false"
+            class="no-select"
             style="--n-padding: 4px;"
           >
             <template #trigger>
@@ -570,9 +558,10 @@ defineExpose({
             </div>
           </n-popover>
           <n-popover
-            class="no-select"
             placement="bottom"
             :trigger="isMobile ? 'click' : 'hover'"
+            :show-arrow="false"
+            class="no-select"
             style="--n-padding: 4px;"
           >
             <template #trigger>

--- a/src/components/main/GearSelectionPanel.vue
+++ b/src/components/main/GearSelectionPanel.vue
@@ -12,6 +12,7 @@ import {
 import FoldableCard from '../templates/FoldableCard.vue'
 import Stepper from '../custom/general/Stepper.vue'
 import GearSlot from '../custom/gear/GearSlot.vue'
+import TooltipButton from '../custom/general/TooltipButton.vue'
 import ModalSelectedGears from '../modals/ModalSelectedGears.vue'
 import {
   XivGearAffixes,
@@ -229,13 +230,42 @@ const handleQuickOperatesDropdownMouseLeave = (event: MouseEvent) => {
 const handleCloseQuickOperatesOptions = () => {
   showQuickOperatesOptions.value = false
 }
-const quickOperatesOptions: DropdownOption[] = [
-  { key: 'add-crafter-mainoff', label: t('添加一套生产主副手'), description: t('添加所有能工巧匠职业的主手工具、副手工具各1件') },
-  { key: 'add-gatherer-mainoff', label: t('添加一套采集主副手'), description: t('添加所有大地使者职业的主手工具、副手工具各1件') },
-  { key: 'add-crafter-aaa', label: t('添加一套生产防具&首饰'), description: t('添加一套能工巧匠职业共用的防具与首饰。如果没有首饰则不会添加。') },
-  { key: 'add-gatherer-aaa', label: t('添加一套采集防具&首饰'), description: t('添加一套大地使者职业共用的防具与首饰。如果没有首饰则不会添加。') },
-  // `aaa` means `attire-and-accessory`, does it droll?
-]
+const quickOperatesOptions = computed(() => {
+  return [
+    {
+      key: 'add-crafter-mainoff',
+      label: t('添加一套生产|全职业主副手'),
+      description: t('添加所有能工巧匠职业的主手工具、副手工具各1件')
+    },
+    {
+      key: 'add-gatherer-mainoff',
+      label: t('添加一套采集|全职业主副手'),
+      description: t('添加所有大地使者职业的主手工具、副手工具各1件')
+    },
+    {
+      key: 'add-crafter-aaa', 
+      label: t('添加一套生产|防具&首饰'), 
+      description: [
+        t('添加一套能工巧匠职业共用的防具与首饰。'),
+        t('如果没有首饰则不会添加。'),
+      ] 
+    },
+    { 
+      key: 'add-gatherer-aaa', 
+      label: t('添加一套采集|防具&首饰'), 
+      description: [
+        t('添加一套大地使者职业共用的防具与首饰。'),
+        t('如果没有首饰则不会添加。'),
+      ] 
+    },
+  ].map(item => {
+    return {
+      key: item.key,
+      labels: item.label.split('|'),
+      description: item.description,
+    }
+  })
+})
 const handleQuickOperatesSelect = (key: string) => {
   if (jobNotSelected.value) {
     NAIVE_UI_MESSAGE.error(t('请先选择职业')); return
@@ -539,31 +569,47 @@ defineExpose({
         </div>
         <n-divider dashed />
         <n-flex class="foot" justify="end">
-          <n-dropdown
+          <n-popover
             v-if="displayQuickOperates"
-            :show="showQuickOperatesOptions"
-            :options="quickOperatesOptions"
-            :render-option="optionsRenderer"
             class="no-select"
             placement="bottom"
-            @select="handleQuickOperatesSelect"
-            @mouseenter="handleQuickOperatesDropdownMouseEnter"
-            @mouseleave="handleQuickOperatesDropdownMouseLeave"
-            :on-clickoutside="handleCloseQuickOperatesOptions"
+            :trigger="isMobile ? 'click' : 'hover'"
           >
-            <n-button
-              icon-placement="right"
-              :disabled="jobNotSelected"
-              @click="showQuickOperatesOptions = !showQuickOperatesOptions"
-              @mouseenter="handleQuickOperatesDropdownMouseEnter"
-              @mouseleave="handleQuickOperatesDropdownMouseLeave"
-            >
-              <template #icon>
-                <n-icon><KeyboardArrowDownRound /></n-icon>
-              </template>
-              {{ t('快速操作') }}
-            </n-button>
-          </n-dropdown>
+            <template #trigger>
+              <n-button
+                icon-placement="right"
+                :disabled="jobNotSelected"
+                @click="showQuickOperatesOptions = !showQuickOperatesOptions"
+                @mouseenter="handleQuickOperatesDropdownMouseEnter"
+                @mouseleave="handleQuickOperatesDropdownMouseLeave"
+              >
+                <template #icon>
+                  <n-icon><KeyboardArrowDownRound /></n-icon>
+                </template>
+                {{ t('快速操作') }}
+              </n-button>
+            </template>
+            <div style="display: grid; gap: 4px 6px; grid-template-columns: minmax(0,1fr) minmax(0,1fr);">
+              <TooltipButton
+                v-for="(option, optionIndex) in quickOperatesOptions"
+                :key="option.key"
+                :tip="option.description"
+                tip-type="n-tooltip"
+                :placement="optionIndex > 1 ? 'bottom' : 'top'"
+                btn-style="--n-padding: 7px 16px; --n-height: auto;"
+                @click="handleQuickOperatesSelect(option.key)"
+              >
+                <div>
+                  <p
+                    v-for="(label, labelIndex) in option.labels"
+                    :key="`quick-operate-label-${option.key}-${labelIndex}`"
+                  >
+                    {{ label }}
+                  </p>
+                </div>
+              </TooltipButton>
+            </div>
+          </n-popover>
           <n-dropdown
             :show="showClearOptions"
             :options="clearOptions"


### PR DESCRIPTION
Related to #150 
* 使用 n-popover 重做下拉菜单，以使用更少代码来解决 选择选项后不关闭下拉菜单 的需求
* 清除对 .n-dropdown-menu 的样式污染