### PR TITLE
feat: 适配 v7 版本客户端

### DIFF
--- a/env.electron.d.ts
+++ b/env.electron.d.ts
@@ -22,6 +22,8 @@ export interface ElectronAPI {
   /** 令窗口关闭 */
   close: () => void;
 
+  /** 获取客户端的当前平台 */
+  clientPlatform?: Promise<"win32" | "darwin" | "linux">;
   /** 获取客户端的当前版本 (格式如 `v1`, `v5a`, `v6`) */
   clientVersion: Promise<string>;
 

--- a/env.electron.d.ts
+++ b/env.electron.d.ts
@@ -43,6 +43,8 @@ export interface ElectronAPI {
   createNewWindow: (id: string, url: string, defaultWidth: number, defaultHeight: number, title: string) => void;
   /** 切换窗口置顶 */
   toggleAlwaysOnTop: () => void;
+  /** (v7+) 关闭所有子窗口 */
+  closeAllChildWindows?: () => void;
   /** 更新标题栏操作按钮的主题 */
   updateTitleBarTheme: (isDarkMode: boolean) => void;
   /** 打开开发者工具 */

--- a/public/version.json
+++ b/public/version.json
@@ -8,6 +8,9 @@
     "recomm_proxy": "https://ghfast.top/",
     "cn_sub_links": [
       "https://share.weiyun.com/0SXWWxJC"
+    ],
+    "mac_cn_sub_links": [
+      "https://share.weiyun.com/0SXWWxJC"
     ]
   }
 }

--- a/public/version.json
+++ b/public/version.json
@@ -1,10 +1,11 @@
 {
   "hqhelper": "2.2.6",
-  "electron": "v6",
+  "electron": "v7",
   "dlink_hqhelper": "~PROXYhttps://github.com/InfSein/hqhelper-dawntrail/releases/download/v~VERSION/static-pages.zip",
-  "dlink_electron": "~PROXYhttps://github.com/InfSein/hqhelper-dawntrail/releases/download/electron.~VERSION/HqHelper.Setup.exe",
+  "dlink_electron": "~PROXYhttps://github.com/InfSein/hqhelper-client/releases/latest/download/HqHelper.WinSetup.exe",
+  "dlink_electron_mac": "~PROXYhttps://github.com/InfSein/hqhelper-client/releases/latest/download/HqHelper.Mac.dmg",
   "client_info": {
-    "recomm_proxy": "https://github.moeyy.xyz/",
+    "recomm_proxy": "https://ghfast.top/",
     "cn_sub_links": [
       "https://share.weiyun.com/0SXWWxJC"
     ]

--- a/src/components/modals/ModalCheckUpdates.vue
+++ b/src/components/modals/ModalCheckUpdates.vue
@@ -268,6 +268,20 @@ const handleDownloadWebPack = async () => {
     }
   }
 }
+const getClientDownloadLink = async () => {
+  let url : string | undefined = ''
+  if (window.electronAPI?.clientPlatform) {
+    const platform = await window.electronAPI.clientPlatform
+    if (platform === 'darwin') {
+      url = versionContent.value?.dlink_electron_mac
+    } else {
+      url = versionContent.value?.dlink_electron
+    }
+  } else {
+    url = versionContent.value?.dlink_electron
+  }
+  return url
+}
 const handleDownloadElectronPack = async () => {
   if (userConfig.value.update_client_builtin) {
     if (!window.electronAPI?.downloadAndOpen) {
@@ -284,7 +298,7 @@ const handleDownloadElectronPack = async () => {
     updateTip.updating_electron = true
 
     saveUpdateSettings()
-    let url = versionContent.value?.dlink_electron
+    let url = await getClientDownloadLink()
     if (!url) {
       alert('Update link not given. Server might be undergoing maintenance...')
     } else if (!latestElectronVersion.value) {
@@ -309,7 +323,7 @@ const handleDownloadElectronPack = async () => {
     }
     saveUpdateSettings()
     const func = window.electronAPI?.openUrlByBrowser ?? window.open
-    let url = versionContent.value?.dlink_electron
+    let url = await getClientDownloadLink()
     if (!url) {
       alert('Update link not given. Server might be undergoing maintenance...')
     } else if (!latestElectronVersion.value) {

--- a/src/components/modals/ModalCloudSync.vue
+++ b/src/components/modals/ModalCloudSync.vue
@@ -436,6 +436,7 @@ const handleDownload = async () => {
     tips.push(t('页面将重载以应用更改。'))
     alert(tips.join('\n'))
     setTimeout(() => {
+      window.electronAPI?.closeAllChildWindows?.()
       location.reload()
     }, 500)
   } else {

--- a/src/components/modals/ModalPreferences.vue
+++ b/src/components/modals/ModalPreferences.vue
@@ -952,6 +952,7 @@ const handleSave = () => {
   if (needReload) {
     const dealReload = () => {
       setTimeout(() => {
+        window.electronAPI?.closeAllChildWindows?.()
         location.reload()
       }, reloadTimeout) // 必须设置一个延迟，不然有些设置不会生效
     }

--- a/src/composables/electron-sync.ts
+++ b/src/composables/electron-sync.ts
@@ -1,32 +1,34 @@
-type Callback = (data: any) => void
+type ElectronSyncEvent = "update-setting" | "workflowStateChanged"
+type ElectronSyncCallback = (data: any) => void
 
 interface ElectronSync {
-  emitSync: (event: string, data: any) => void
-  onSync: (event: string, callback: Callback) => void
+  emitSync: (event: ElectronSyncEvent, data: any) => void
+  onSync: (event: ElectronSyncEvent, callback: ElectronSyncCallback) => void
   isElectron: boolean
 }
 
 declare global {
   interface Window {
     $syncStore?: {
-      emit: (event: string, data: any) => void
-      on: (event: string, callback: Callback) => void
-    }
+      emit: (event: ElectronSyncEvent, data: any) => void
+      on: (event: ElectronSyncEvent, callback: ElectronSyncCallback) => void
+    },
   }
 }
 
 export function useElectronSync(): ElectronSync {
   const isElectron = typeof window !== 'undefined' && !!window.$syncStore
 
-  function emitSync(event: string, data: any) {
-    console.log('emit-sync was called', isElectron, data)
+  function emitSync(event: ElectronSyncEvent, data: any) {
     if (isElectron) {
+      console.log('emitSync', event, data)
       window.$syncStore!.emit(event, data)
     }
   }
 
-  function onSync(event: string, callback: Callback) {
+  function onSync(event: ElectronSyncEvent, callback: ElectronSyncCallback) {
     if (isElectron) {
+      console.log('onSync', event)
       window.$syncStore!.on(event, callback)
     }
   }

--- a/src/composables/electron-sync.ts
+++ b/src/composables/electron-sync.ts
@@ -1,0 +1,35 @@
+type Callback = (data: any) => void
+
+interface ElectronSync {
+  emitSync: (event: string, data: any) => void
+  onSync: (event: string, callback: Callback) => void
+  isElectron: boolean
+}
+
+declare global {
+  interface Window {
+    $syncStore?: {
+      emit: (event: string, data: any) => void
+      on: (event: string, callback: Callback) => void
+    }
+  }
+}
+
+export function useElectronSync(): ElectronSync {
+  const isElectron = typeof window !== 'undefined' && !!window.$syncStore
+
+  function emitSync(event: string, data: any) {
+    console.log('emit-sync was called', isElectron, data)
+    if (isElectron) {
+      window.$syncStore!.emit(event, data)
+    }
+  }
+
+  function onSync(event: string, callback: Callback) {
+    if (isElectron) {
+      window.$syncStore!.on(event, callback)
+    }
+  }
+
+  return { emitSync, onSync, isElectron }
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -18,6 +18,7 @@ export interface AppVersionJson {
   client_info: {
     recomm_proxy: string;
     cn_sub_links: string[];
+    mac_cn_sub_links: string[];
   }
 }
 

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -14,6 +14,7 @@ export interface AppVersionJson {
   electron: string;
   dlink_hqhelper: string;
   dlink_electron: string;
+  dlink_electron_mac: string;
   client_info: {
     recomm_proxy: string;
     cn_sub_links: string[];

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,6 +3,7 @@ import MainPage from '@/views/MainPage.vue'
 import FoodAndTincPage from '@/views/FoodAndTincPage.vue'
 import GatherClockPage from '@/views/GatherClockPage.vue'
 import WorkflowPage from '@/views/WorkflowPage.vue'
+import WorkflowProcessPage from '@/views/WorkflowProcessPage.vue'
 import DownloadPage from '@/views/DownloadPage.vue'
 import MacroManagePage from '@/views/MacroManagePage.vue'
 import ErrorPage404 from '@/views/ErrorPage404.vue'
@@ -17,6 +18,7 @@ const routes = [
   { path: '/fthelper', component: FoodAndTincPage },
   { path: '/gatherclock', component: GatherClockPage },
   { path: '/workflow', component: WorkflowPage },
+  { path: '/workflow_process', component: WorkflowProcessPage },
   { path: '/download', component: DownloadPage },
   { path: '/macromanage', component: MacroManagePage },
   {

--- a/src/views/DownloadPage.vue
+++ b/src/views/DownloadPage.vue
@@ -211,9 +211,9 @@ const handleDownloadBtnClick = (link: string) => {
           </div>
           <p>{{ t('※仅适用于 Mac OS 10.13 或更高版本') }}</p>
           <p>{{ t('※仅适用于搭载了M系列芯片的设备') }}</p>
-          <n-alert type="info" :title="t('提示')" style="width: fit-content;">
-            <p>{{ t('安装时提示「“HqHelper”已损坏，无法打开。你应该将它移到废纸篓。」是正常的，因为我们暂时没有能力提供 Apple 开发者签名。') }}</p>
-            <p>{{ t('你需要解除安全检查限制或是将 HqHelper 添加到白名单，方可成功安装。') }}</p>
+          <n-alert type="info" :title="t('提示')" style="width: fit-content; margin-top: 8px;">
+            <p>{{ t('我们暂时没有能力提供 Apple 开发者签名，安装时可能会提示「“HqHelper”已损坏，无法打开。你应该将它移到废纸篓」。') }}</p>
+            <p>{{ t('你需要解除安全检查限制或是将 HqHelper 添加到白名单方可成功安装。') }}</p>
             <p>
               <span>{{ t('请参阅：') }}</span>
               <a target="_blank" href="https://zhuanlan.zhihu.com/p/135948430">https://zhuanlan.zhihu.com/p/135948430</a>

--- a/src/views/DownloadPage.vue
+++ b/src/views/DownloadPage.vue
@@ -111,6 +111,15 @@ const macAppBtns = computed(() => {
       ghost: false,
     }
   ]
+  vi.client_info.mac_cn_sub_links.forEach((sublink) => {
+    res.push({
+      icon: LandscapeRound,
+      text: t('国内下载链接{index}', index++),
+      type: 'primary',
+      link: sublink,
+      ghost: true,
+    })
+  })
   res.push({
     icon: FlightLandRound,
     text: t('国际下载链接'),

--- a/src/views/DownloadPage.vue
+++ b/src/views/DownloadPage.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, inject, onMounted, ref } from 'vue'
 import {
-  NBackTop, NButton, NDivider, NIcon, NSpin,
+  NAlert, NBackTop, NButton, NDivider, NIcon, NSpin,
   useMessage
 } from 'naive-ui'
 import type { Type } from 'naive-ui/es/button/src/interface'
@@ -91,6 +91,35 @@ const winAppBtns = computed(() => {
   })
   return res
 })
+const macAppBtns = computed(() => {
+  const vi = appVersionInfo.value
+  if (!vi) return []
+  const dlink = vi.dlink_electron_mac.replace('~VERSION', vi.electron)
+  let index = 1
+  const res : {
+    icon: typeof LandscapeRound;
+    text: string;
+    type: Type;
+    link: string;
+    ghost: boolean;
+  }[] = [
+    {
+      icon: LandscapeRound,
+      text: t('国内下载链接{index}', index++),
+      type: 'primary',
+      link: dlink.replace('~PROXY', vi.client_info.recomm_proxy),
+      ghost: false,
+    }
+  ]
+  res.push({
+    icon: FlightLandRound,
+    text: t('国际下载链接'),
+    type: 'info',
+    link: dlink.replace('~PROXY', ''),
+    ghost: false,
+  })
+  return res
+})
 
 const handleDownloadBtnClick = (link: string) => {
   window.open(link, '_blank')
@@ -157,7 +186,41 @@ const handleDownloadBtnClick = (link: string) => {
         <i class="xiv square-2"></i>
         <span class="card-title-text">{{ t('{platform} 客户端', 'Mac') }}</span>
       </template>
-      <div class="content-block">{{ t('开发中') }}</div>
+      <div class="content-block">
+        <div v-if="loading" class="spin-container">
+          <n-spin size="small" />
+          <div>{{ t('正在加载……') }}</div>
+        </div>
+        <div v-else class="flex-col gap-4">
+          <p>{{ t('当前最新版本：{ver}', appVersionInfo?.electron) }}</p>
+          <p>{{ t('点击下方按钮来进行下载。') }}</p>
+          <div class="download-btn-container">
+            <n-button
+              v-for="(btn, btnIndex) in macAppBtns"
+              :key="'mac-app-btn-' + btnIndex"
+              size="small"
+              :type="btn.type"
+              :ghost="btn.ghost"
+              @click="() => handleDownloadBtnClick(btn.link)"
+            >
+              <template #icon>
+                <n-icon :size="16" :component="btn.icon" />
+              </template>
+              {{ btn.text }}
+            </n-button>
+          </div>
+          <p>{{ t('※仅适用于 Mac OS 10.13 或更高版本') }}</p>
+          <p>{{ t('※仅适用于搭载了M系列芯片的设备') }}</p>
+          <n-alert type="info" :title="t('提示')" style="width: fit-content;">
+            <p>{{ t('安装时提示「“HqHelper”已损坏，无法打开。你应该将它移到废纸篓。」是正常的，因为我们暂时没有能力提供 Apple 开发者签名。') }}</p>
+            <p>{{ t('你需要解除安全检查限制或是将 HqHelper 添加到白名单，方可成功安装。') }}</p>
+            <p>
+              <span>{{ t('请参阅：') }}</span>
+              <a target="_blank" href="https://zhuanlan.zhihu.com/p/135948430">https://zhuanlan.zhihu.com/p/135948430</a>
+            </p>
+          </n-alert>
+        </div>
+      </div>
     </FoldableCard>
     <FoldableCard card-key="download-ios">
       <template #header>

--- a/src/views/WorkflowPage.vue
+++ b/src/views/WorkflowPage.vue
@@ -11,6 +11,7 @@ import {
   QueryStatsFilled,
   TableViewOutlined,
   AllInclusiveSharp,
+  OpenInNewOutlined,
   VisibilitySharp, VisibilityOffSharp,
   UnfoldMoreSharp, UnfoldLessSharp,
 } from '@vicons/material'
@@ -314,6 +315,27 @@ const recommGroupAllCollapsed = computed(() => {
   }
   return allCollapsed
 })
+
+const handleOpenProcessInNewWindow = () => {
+  const pageTitle = t('工作流流程')
+  const pageUrl = document.location.origin + document.location.pathname + `#/workflow_process?mode=overlay`
+  const width = 500; const height = 800
+  if (window.electronAPI?.createNewWindow) {
+    window.electronAPI.createNewWindow(
+      'workflow-process',
+      pageUrl,
+      width,
+      height,
+      pageTitle
+    )
+  } else {
+    window.open(
+      pageUrl,
+      pageTitle,
+      `height=${height}, width=${width}, top=200, left=200`
+    )
+  }
+}
 const handleHideOrShowChsOfflineItems = () => {
   currentWorkflow.value.recommData.hideChsOfflineItems = !currentWorkflow.value.recommData.hideChsOfflineItems
   const message = currentWorkflow.value.recommData.hideChsOfflineItems
@@ -572,6 +594,16 @@ const setInventoryByStatementPrepared = () => {
               />
 
               <n-float-button-group v-if="!isMobile" right="20px" bottom="5px">
+                <n-tooltip :trigger="isMobile ? 'manual' : 'hover'" placement="left">
+                  <template #trigger>
+                    <n-float-button @click="handleOpenProcessInNewWindow">
+                      <n-icon>
+                        <OpenInNewOutlined />
+                      </n-icon>
+                    </n-float-button>
+                  </template>
+                  {{ t('在新窗口中打开') }}
+                </n-tooltip>
                 <n-tooltip v-if="recommProcessGroups.length && itemServer === 'chs'" :trigger="isMobile ? 'manual' : 'hover'" placement="left">
                   <template #trigger>
                     <n-float-button @click="handleHideOrShowChsOfflineItems">

--- a/src/views/WorkflowProcessPage.vue
+++ b/src/views/WorkflowProcessPage.vue
@@ -1,16 +1,16 @@
 <script setup lang="ts">
 import { computed, inject, ref, watch, type Ref } from 'vue'
 import {
-  NBackTop, NFloatButton, NFloatButtonGroup, NIcon, NTooltip, 
-  useMessage
+  NBackTop,
 } from 'naive-ui'
-import {
-  SettingsSharp,
-  VisibilitySharp, VisibilityOffSharp,
-  UnfoldMoreSharp, UnfoldLessSharp,
-} from '@vicons/material'
+// import {
+//   SettingsSharp,
+//   VisibilitySharp, VisibilityOffSharp,
+//   UnfoldMoreSharp, UnfoldLessSharp,
+// } from '@vicons/material'
 import ModalPreferences from '@/components/modals/ModalPreferences.vue'
 import { useStore } from '@/store'
+import { useElectronSync } from '@/composables/electron-sync'
 import { fixWorkState } from '@/models/workflow'
 import type { UserConfigModel } from '@/models/config-user'
 import { type FuncConfigModel } from '@/models/config-func'
@@ -20,14 +20,16 @@ import { useFufuCal } from '@/tools/use-fufu-cal'
 import UseConfig from '@/tools/use-config'
 import CraftRecommProcess from '@/components/custom/general/CraftRecommProcess.vue'
 import type { SettingGroupKey } from '@/models'
+import { deepCopy } from '@/tools'
 
 const t = inject<(text: string, ...args: any[]) => string>('t') ?? (() => { return '' })
-const isMobile = inject<Ref<boolean>>('isMobile') ?? ref(false)
+// const isMobile = inject<Ref<boolean>>('isMobile') ?? ref(false)
 const userConfig = inject<Ref<UserConfigModel>>('userConfig')!
 const funcConfig = inject<Ref<FuncConfigModel>>('funcConfig')!
 
 const store = useStore()
-const NAIVE_UI_MESSAGE = useMessage()
+// const NAIVE_UI_MESSAGE = useMessage()
+const { emitSync, onSync } = useElectronSync()
 const { calItems } = useNbbCal()
 const { getStatementData, getProStatementData, calRecommProcessData, calRecommProcessGroups } = useFufuCal(userConfig, funcConfig, t)
 const {
@@ -40,6 +42,7 @@ const currentWorkflow = computed(() => {
   return workState.value.workflows[workState.value.currentWorkflow]
 })
 
+const ignoreNextUpdate = ref(false)
 const disable_workstate_cache = userConfig.value.disable_workstate_cache ?? false
 if (!disable_workstate_cache) {
   const cachedWorkState = userConfig.value.workflow_cache_work_state
@@ -53,8 +56,13 @@ if (!disable_workstate_cache) {
     if (workState.value && userConfig) {
       try {
         await Promise.resolve()
+        if (ignoreNextUpdate.value) {
+          ignoreNextUpdate.value = false
+          return
+        }
         userConfig.value.workflow_cache_work_state = workState.value
         store.commit('setUserConfig', userConfig.value)
+        emitSync('workflowStateChanged', deepCopy(userConfig.value))
       } catch (error) {
         console.error('Error handling workState change:', error)
       }
@@ -63,6 +71,10 @@ if (!disable_workstate_cache) {
     }
   }, {deep: true})
 }
+onSync('workflowStateChanged', (userConfig: UserConfigModel) => {
+  ignoreNextUpdate.value = true
+  workState.value = userConfig.workflow_cache_work_state
+})
 
 const showPreferencesModal = ref(false)
 const preferenceSettingGroup = ref<SettingGroupKey | undefined>(undefined)
@@ -162,36 +174,6 @@ watch(recommProcessGroups, async () => {
 })
 fixRecommMaps()
 fixPreparedItems()
-
-const recommGroupAllCollapsed = computed(() => {
-  let allCollapsed = true
-  for (let i = 0; i < recommProcessGroups.value.length; i++) {
-    if (currentWorkflow.value.recommData.expandedBlocks[i] && currentWorkflow.value.recommData.expandedBlocks[i].length > 0) {
-      allCollapsed = false
-    }
-  }
-  return allCollapsed
-})
-const handleHideOrShowChsOfflineItems = () => {
-  currentWorkflow.value.recommData.hideChsOfflineItems = !currentWorkflow.value.recommData.hideChsOfflineItems
-  const message = currentWorkflow.value.recommData.hideChsOfflineItems
-    ? t('已隐藏国服未实装物品')
-    : t('已显示国服未实装物品')
-  NAIVE_UI_MESSAGE.success(message)
-}
-const handleCollapseOrUncollapseAllRecommGroupBlocks = () => {
-  const cacheRecommGroupAllCollapsed = recommGroupAllCollapsed.value
-  // 这里不能直接引用 computed 的值，因为它会在折叠/展开过程中变化
-  for (let i = 0; i < recommProcessGroups.value.length; i++) {
-    currentWorkflow.value.recommData.expandedBlocks[i] = cacheRecommGroupAllCollapsed ? ['1'] : []
-  }
-}
-const handleRecommSettingButtonClick = () => {
-  preferenceAppShowUP.value = false
-  preferenceAppShowFP.value = true
-  preferenceSettingGroup.value = 'recomm_process'
-  showPreferencesModal.value = true
-}
 // #endregion
 </script>
 
@@ -205,41 +187,6 @@ const handleRecommSettingButtonClick = () => {
       content-max-width="auto"
       :hide-chs-offline-items="currentWorkflow.recommData.hideChsOfflineItems"
     />
-
-    <n-float-button-group v-if="!isMobile" right="20px" bottom="5px">
-      <n-tooltip v-if="recommProcessGroups.length && itemServer === 'chs'" :trigger="isMobile ? 'manual' : 'hover'" placement="left">
-        <template #trigger>
-          <n-float-button @click="handleHideOrShowChsOfflineItems">
-            <n-icon>
-              <VisibilitySharp v-if="currentWorkflow.recommData.hideChsOfflineItems" />
-              <VisibilityOffSharp v-else />
-            </n-icon>
-          </n-float-button>
-        </template>
-        {{ currentWorkflow.recommData.hideChsOfflineItems ? t('显示国服未实装物品') : t('隐藏国服未实装物品') }}
-      </n-tooltip>
-      <n-tooltip v-if="recommProcessGroups.length" :trigger="isMobile ? 'manual' : 'hover'" placement="left">
-        <template #trigger>
-          <n-float-button @click="handleCollapseOrUncollapseAllRecommGroupBlocks">
-            <n-icon>
-              <UnfoldMoreSharp v-if="recommGroupAllCollapsed" />
-              <UnfoldLessSharp v-else />
-            </n-icon>
-          </n-float-button>
-        </template>
-        {{ recommGroupAllCollapsed ? t('全部展开') : t('全部折叠') }}
-      </n-tooltip>
-      <n-tooltip :trigger="isMobile ? 'manual' : 'hover'" placement="left">
-        <template #trigger>
-          <n-float-button @click="handleRecommSettingButtonClick">
-            <n-icon>
-              <SettingsSharp />
-            </n-icon>
-          </n-float-button>
-        </template>
-        {{ t('设置') }}
-      </n-tooltip>
-    </n-float-button-group>
 
     <ModalPreferences
       v-model:show="showPreferencesModal"

--- a/src/views/WorkflowProcessPage.vue
+++ b/src/views/WorkflowProcessPage.vue
@@ -8,7 +8,6 @@ import {
 //   VisibilitySharp, VisibilityOffSharp,
 //   UnfoldMoreSharp, UnfoldLessSharp,
 // } from '@vicons/material'
-import ModalPreferences from '@/components/modals/ModalPreferences.vue'
 import { useStore } from '@/store'
 import { useElectronSync } from '@/composables/electron-sync'
 import { fixWorkState } from '@/models/workflow'
@@ -19,7 +18,6 @@ import { useNbbCal } from '@/tools/use-nbb-cal'
 import { useFufuCal } from '@/tools/use-fufu-cal'
 import UseConfig from '@/tools/use-config'
 import CraftRecommProcess from '@/components/custom/general/CraftRecommProcess.vue'
-import type { SettingGroupKey } from '@/models'
 import { deepCopy } from '@/tools'
 
 const t = inject<(text: string, ...args: any[]) => string>('t') ?? (() => { return '' })
@@ -75,11 +73,6 @@ onSync('workflowStateChanged', (userConfig: UserConfigModel) => {
   ignoreNextUpdate.value = true
   workState.value = userConfig.workflow_cache_work_state
 })
-
-const showPreferencesModal = ref(false)
-const preferenceSettingGroup = ref<SettingGroupKey | undefined>(undefined)
-const preferenceAppShowUP = ref(false)
-const preferenceAppShowFP = ref(false)
 
 // #region content-statistics
 const craftTargetsArray = computed(() => {
@@ -186,13 +179,6 @@ fixPreparedItems()
       content-max-height="auto"
       content-max-width="auto"
       :hide-chs-offline-items="currentWorkflow.recommData.hideChsOfflineItems"
-    />
-
-    <ModalPreferences
-      v-model:show="showPreferencesModal"
-      :setting-group="preferenceSettingGroup"
-      :app-show-up="preferenceAppShowUP"
-      :app-show-fp="preferenceAppShowFP"
     />
 
     <n-back-top />


### PR DESCRIPTION
* 推出Mac OS客户端
* 追加在新窗口中打开推荐流程的功能（仅限工作流使用，仅限v7+客户端）
* 更换默认加速服务
* 现在在打开多个窗口时，尝试打开相同的窗口会将其带到前台，而非再打开一个
* 现在在打开多个窗口时，调整其中一个窗口的设置会正确地影响其他的窗口设置
* 现在若是在更新期间出错，会正确展示错误信息并允许重试，而非卡在某个阶段
* 在修改设置、导入云端数据等需要重载页面的场合，会首先关闭所有子窗口